### PR TITLE
Do not override computed prop config.server.host.

### DIFF
--- a/configs/server.js
+++ b/configs/server.js
@@ -10,4 +10,3 @@ require('bedrock-server');
 config.server.port = 45443;
 config.server.httpPort = 45080;
 config.server.domain = 'localhost';
-config.server.host = 'localhost:45443';

--- a/lib/ledger.js
+++ b/lib/ledger.js
@@ -72,7 +72,7 @@ bedrock.events.on('bedrock.started', async () => {
     {ledgerNodeId: ledgerNode.id});
   // creates a peerUrl at the node's address
   const _getPeerUrl = ({peerId, hostname}) => `https://${hostname}` +
-          `/consensus/continuity2017/peers/${encodeURIComponent(peerId)}`;
+    `/consensus/continuity2017/peers/${encodeURIComponent(peerId)}`;
   const peers = endpoints.filter(({targetNode}) => targetNode !== localPeerId)
     .map(({targetNode, hostname}) => ({
       id: targetNode,

--- a/lib/ledger.js
+++ b/lib/ledger.js
@@ -15,7 +15,6 @@ const fs = require('fs').promises;
 const jsigs = require('jsonld-signatures');
 const pRetry = require('p-retry');
 const {promisify} = require('util');
-const {CapabilityInvocation} = require('@digitalbazaar/zcapld');
 const v1 = require('did-veres-one');
 const {Ed25519Signature2020} =
   require('@digitalbazaar/ed25519-signature-2020');
@@ -28,8 +27,12 @@ const logger = require('./logger');
 const getAgentIterator = promisify(brLedgerAgent.getAgentIterator);
 const {purposes: {AssertionProofPurpose}} = jsigs;
 const {config, util: {BedrockError}} = bedrock;
-const {constants} = config;
 const brLedgerAgentAdd = promisify(brLedgerAgent.add);
+/*
+ * Uncomment these if we use _sendWitnessPool again.
+const {constants} = config;
+const {CapabilityInvocation} = require('@digitalbazaar/zcapld');
+*/
 
 // the maximum number of milliseconds between two retries
 const RETRY_MAX_TIMEOUT = 30000;
@@ -358,6 +361,8 @@ async function _getEndpoints({hostnames}) {
   })()));
 }
 
+/*
+ * FIXME delete or update _sendWitnessPool
 async function _sendWitnessPool({witnessPoolId, maintainerDoc, ledgerId}) {
   const capabilityInvocationKey =
     maintainerDoc.methodFor({purpose: 'capabilityInvocation'});
@@ -421,3 +426,4 @@ async function _sendWitnessPool({witnessPoolId, maintainerDoc, ledgerId}) {
   logger.debug('Sending witnessPool operation.', {operation: signedOperation});
   await target.client.sendOperation({operation: signedOperation});
 }
+*/

--- a/lib/ledger.js
+++ b/lib/ledger.js
@@ -67,11 +67,14 @@ bedrock.events.on('bedrock.started', async () => {
   // Ensure we filter out the local peer from the list of peers
   const localPeerId = await ledgerNode.consensus._localPeers.getPeerId(
     {ledgerNodeId: ledgerNode.id});
-
+  // creates a peerUrl at the node's address
+  const _getPeerUrl = ({peerId, hostname}) => `https://${hostname}` +
+          `/consensus/continuity2017/peers/${encodeURIComponent(peerId)}`;
   const peers = endpoints.filter(({targetNode}) => targetNode !== localPeerId)
-    .map(({targetNode}) => {
-      return {id: targetNode, url: targetNode};
-    });
+    .map(({targetNode, hostname}) => ({
+      id: targetNode,
+      url: _getPeerUrl({peerId: targetNode, hostname})
+    }));
 
   const promises = peers.map(async peer => {
     try {

--- a/node-1.js
+++ b/node-1.js
@@ -18,7 +18,7 @@ config.server.port = 46443;
 config.server.httpPort = 46080;
 config.server.domain = 'node-1.veres.one.local';
 config.mongodb.name = 'veres_one_node_1';
-config.jobs.prefix = 'veres_one_jobs_node_1';
+config.jobs.queueOptions.prefix = 'veres_one_jobs_node_1';
 
 // ensure TLS is used for all https-agent connections
 config['https-agent'].rejectUnauthorized = false;

--- a/node-1.js
+++ b/node-1.js
@@ -18,6 +18,7 @@ config.server.port = 46443;
 config.server.httpPort = 46080;
 config.server.domain = 'node-1.veres.one.local';
 config.mongodb.name = 'veres_one_node_1';
+config.jobs.prefix = 'veres_one_jobs_node_1';
 
 // ensure TLS is used for all https-agent connections
 config['https-agent'].rejectUnauthorized = false;

--- a/node-2.js
+++ b/node-2.js
@@ -18,7 +18,7 @@ config.server.port = 47443;
 config.server.httpPort = 47080;
 config.server.domain = 'node-2.veres.one.local';
 config.mongodb.name = 'veres_one_node_2';
-config.jobs.prefix = 'veres_one_jobs_node_2';
+config.jobs.queueOptions.prefix = 'veres_one_jobs_node_2';
 
 // ensure TLS is used for all https-agent connections
 config['https-agent'].rejectUnauthorized = false;

--- a/node-2.js
+++ b/node-2.js
@@ -18,6 +18,7 @@ config.server.port = 47443;
 config.server.httpPort = 47080;
 config.server.domain = 'node-2.veres.one.local';
 config.mongodb.name = 'veres_one_node_2';
+config.jobs.prefix = 'veres_one_jobs_node_2';
 
 // ensure TLS is used for all https-agent connections
 config['https-agent'].rejectUnauthorized = false;

--- a/node-3.js
+++ b/node-3.js
@@ -18,7 +18,7 @@ config.server.port = 48443;
 config.server.httpPort = 48080;
 config.server.domain = 'node-3.veres.one.local';
 config.mongodb.name = 'veres_one_node_3';
-config.jobs.prefix = 'veres_one_jobs_node_3';
+config.jobs.queueOptions.prefix = 'veres_one_jobs_node_3';
 
 // ensure TLS is used for all https-agent connections
 config['https-agent'].rejectUnauthorized = false;

--- a/node-3.js
+++ b/node-3.js
@@ -18,6 +18,7 @@ config.server.port = 48443;
 config.server.httpPort = 48080;
 config.server.domain = 'node-3.veres.one.local';
 config.mongodb.name = 'veres_one_node_3';
+config.jobs.prefix = 'veres_one_jobs_node_3';
 
 // ensure TLS is used for all https-agent connections
 config['https-agent'].rejectUnauthorized = false;

--- a/node-4.js
+++ b/node-4.js
@@ -18,6 +18,7 @@ config.server.port = 49443;
 config.server.httpPort = 49080;
 config.server.domain = 'node-4.veres.one.local';
 config.mongodb.name = 'veres_one_node_4';
+config.jobs.prefix = 'veres_one_jobs_node_4';
 
 // ensure TLS is used for all https-agent connections
 config['https-agent'].rejectUnauthorized = false;

--- a/node-4.js
+++ b/node-4.js
@@ -18,7 +18,7 @@ config.server.port = 49443;
 config.server.httpPort = 49080;
 config.server.domain = 'node-4.veres.one.local';
 config.mongodb.name = 'veres_one_node_4';
-config.jobs.prefix = 'veres_one_jobs_node_4';
+config.jobs.queueOptions.prefix = 'veres_one_jobs_node_4';
 
 // ensure TLS is used for all https-agent connections
 config['https-agent'].rejectUnauthorized = false;


### PR DESCRIPTION
1. removes override of computed property `config.server.host`
2. Adds a unique bedrock jobs `queueOptions.prefix` to each node
3. Updates peerNode generation so `peer.url` points at that node's peer history api endpoint.